### PR TITLE
Added deprecation notice for EngineBlock 5.x range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**_Warning_: This project has been deprecated. All tests provided have been embedded within the 5.x range of [OpenConext-engineblock](https://github.com/OpenConext/OpenConext-engineblock). Any tests added must target the 4.x range of OpenConext-engineblock and should also be added to the 5.x range of OpenConext-engineblock (5.x-dev branch)**
+
 # OpenConext Engine Test Stand
 
 ![](http://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Multicoupling-Docking-System.jpg/640px-Multicoupling-Docking-System.jpg)


### PR DESCRIPTION
The tests provided by EngineBlock teststand have been embedded within the 5.x range of EngineBlock. This means that this project should no longer be used from the first production release of EngineBlock 5.x onwards.
